### PR TITLE
feat: changed ctx key type from string to any

### DIFF
--- a/pkg/di/provide.go
+++ b/pkg/di/provide.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 )
 
-func Provide[T any](ctx context.Context, key string) T {
+func Provide[T any](ctx context.Context, key any) T {
 	val := ctx.Value(key)
 	if val == nil {
 		panic(fmt.Sprintf("%v key does not registered in DI", key))

--- a/pkg/di/register.go
+++ b/pkg/di/register.go
@@ -4,6 +4,6 @@ import (
 	"context"
 )
 
-func Register(ctx context.Context, key string, val any) context.Context {
+func Register(ctx context.Context, key any, val any) context.Context {
 	return context.WithValue(ctx, key, val)
 }

--- a/pkg/grpcext/interceptor.go
+++ b/pkg/grpcext/interceptor.go
@@ -42,7 +42,7 @@ func UnaryContextMetadataInterceptor() grpc.UnaryServerInterceptor {
 	}
 }
 
-func DIUnaryInterceptor[T any](key string, provide func() T) grpc.UnaryServerInterceptor {
+func DIUnaryInterceptor[T any](key any, provide func() T) grpc.UnaryServerInterceptor {
 	value := provide()
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		return handler(di.Register(ctx, key, value), req)

--- a/pkg/muxext/middleware.go
+++ b/pkg/muxext/middleware.go
@@ -31,7 +31,7 @@ func AuthMiddleware(scopes ...string) mux.MiddlewareFunc {
 	}
 }
 
-func DIMiddleware[T any](key string, provide func() T) mux.MiddlewareFunc {
+func DIMiddleware[T any](key any, provide func() T) mux.MiddlewareFunc {
 	value := provide()
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {

--- a/pkg/worker/builder.go
+++ b/pkg/worker/builder.go
@@ -7,7 +7,7 @@ import (
 
 type Builder func(context.Context) context.Context
 
-func DIBuilder[T any](key string, provide func() T) Builder {
+func DIBuilder[T any](key any, provide func() T) Builder {
 	value := provide()
 	return func(ctx context.Context) context.Context {
 		return di.Register(ctx, key, value)


### PR DESCRIPTION
Changed the context key type from string to any to align with the standard library’s `context.WithValue`.
This change allows for the use of custom key types, preventing potential key collisions in the context.